### PR TITLE
feat: Snacks picker integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The plugin exports the following commands:
 - `ApidocsInstall` - will fetch the list of supported documentation sources (lua, openjdk, rust...) from devdocs.io and ask you which one you wish to install. Note that downloading+installing can take over a minute and WILL TEMPORARILY FREEZE YOUR NEOVIM. This is because the plugin leverages neovim's tree-sitter to post-process the files. This happens only when installing a source, and never again after that.
 - `ApidocsOpen` (requires telescope.nvim) - open a picker listing all apidocs. If you want to display only a subset of sources, call the lua function: `:lua require("apidocs").apidocs_open({restrict_sources={"rust"}})`
 - `ApidocsSearch` (requires telescope.nvim) - open a picker to grep for text in all apidocs. If you want to display only a subset of sources, call the lua function: `:lua require("apidocs").apidocs_search({restrict_sources={"rust"}})`
-- `ApidocsSelect` - open a ui.select prompt listing all apidocs. If you want to display only a subset of sources, call the lua function: `:lua require("apidocs").apidocs_open({restrict_sources={"rust"}, use_ui_select=true})`
 - `ApidocsUninstall` - allows to uninstall sources. Press tab to get a completion on the available ones.
 
 ## Advanced usage
@@ -29,7 +28,8 @@ When a link takes you to a specific part of a document, you may have to press `n
 
 This plugin requires:
 
-- the telescope.nvim neovim plugin (optional, needed for preview and search)
+- the [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) neovim plugin (optional, needed for preview and search)
+- the [snacks.nvim](https://github.com/folke/snacks.nvim) neovim plugin (optional, needed for preview and search)
 - the <https://github.com/rkd77/elinks> elinks TUI browser, to convert HTML
 - ripgrep
 - curl
@@ -41,11 +41,14 @@ This plugin requires:
 return {
   'emmanueltouzery/apidocs.nvim',
   dependencies = {
-    'nvim-telescope/telescope.nvim',
+    'nvim-telescope/telescope.nvim', -- or, 'folke/snacks.nvim'
   },
   cmd = { 'ApidocsSearch', 'ApidocsInstall', 'ApidocsOpen', 'ApidocsSelect', 'ApidocsUninstall' },
   config = function()
     require('apidocs').setup()
+    -- Picker will be auto-detected. To select a picker of your choice explicitly you can set picker by the configuration option 'picker':
+    -- require('apidocs').setup({picker = "snacks"})
+    -- Possible options are 'ui_select', 'telescope', and 'snacks'
   end,
   keys = {
     { '<leader>sad', '<cmd>ApidocsOpen<cr>', desc = 'Search Api Doc' },

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -29,10 +29,7 @@ local function apidocs_open(opts)
   if opts and opts.picker then
     picker = opts.picker
   end
-  if picker == "snacks" then
-    snacks.apidocs_open(opts)
-    return
-  end
+
   local docs_path = common.data_folder()
   local fs = vim.uv.fs_scandir(docs_path)
   local candidates = {}
@@ -71,6 +68,11 @@ local function apidocs_open(opts)
         end
       end
     end
+  end
+
+  if picker == "snacks" then
+    snacks.apidocs_open(opts)
+    return
   end
 
   for _, name in ipairs(installed_docs) do

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -1,107 +1,173 @@
 local common = require("apidocs.common")
 local install = require("apidocs.install")
 local telescope = require("apidocs.telescope")
+local snacks = require("apidocs.snacks")
 
-local function apidocs_open(opts)
-  local docs_path = common.data_folder()
-  local fs = vim.uv.fs_scandir(docs_path)
-  local candidates = {}
-  local installed_docs = {}
-  while true do
-    local name, type = vim.uv.fs_scandir_next(fs)
-    if not name then break end
-    if type == 'directory' then
-      if opts and opts.restrict_sources then
-        if vim.tbl_contains(opts.restrict_sources, name) then
-          table.insert(installed_docs, name)
-        end
-      else
-        table.insert(installed_docs, name)
-      end
-    end
-  end
+Config = {}
 
-  if opts and opts.ensure_installed then
-    for _, source in ipairs(opts.ensure_installed) do
-      if not vim.tbl_contains(installed_docs, source) then
-        if slugs_to_mtimes == nil then
-          install.fetch_slugs_and_mtimes_and_then(function (slugs_to_mtimes)
-            install.apidoc_install(source, slugs_to_mtimes, function()
-              apidocs_open(opts, slugs_to_mtimes)
-            end)
-          end)
-          return
-        else
-          install.apidoc_install(source, slugs_to_mtimes, function()
-              apidocs_open(opts, slugs_to_mtimes)
-          end)
-          return
-        end
-      end
-    end
-  end
-
-  for _, name in ipairs(installed_docs) do
-    local fs2 = vim.uv.fs_scandir(docs_path .. "/" .. name)
-    while true do
-      local name2, type2 = vim.uv.fs_scandir_next(fs2)
-      if not name2 then break end
-      if type2 == 'file' and vim.endswith(name2, ".html.md") then
-        local name_no_txt = name2:gsub("#.*$", "")
-        table.insert(candidates, {display = name .. "/" .. name_no_txt, path = name .. "/" .. name2})
-      end
-    end
-  end
-
-  if opts and opts.use_ui_select then
-    local display_list = vim.tbl_map(function(c) return c.display end, candidates)
-    local path_list = vim.tbl_map(function(c) return c.path end, candidates)
-    vim.ui.select(display_list, {prompt="Pick a documentation to view"}, function(item, idx)
-      if item ~= nil then
-        common.open_doc_in_new_window(docs_path .. path_list[idx])
-      end
-    end)
-  else
-    telescope.apidocs_open(opts, slugs_to_mtimes, candidates)
-  end
+local function set_picker(opts)
+	if opts and (opts.picker == "snacks" or opts.picker == "telescope" or opts.picker == "ui_select") then
+		return opts
+	end
+	if not opts then
+		opts = {}
+	end
+	if package.loaded["snacks"] then
+		opts.picker = "snacks"
+		return opts
+	end
+	if package.loaded["telescope"] then
+		opts.picker = "telescope"
+		return opts
+	end
+	opts.picker = "ui_select"
+	return opts
 end
 
-local function setup()
-  vim.api.nvim_create_user_command("ApidocsInstall", install.apidocs_install, {})
-  vim.api.nvim_create_user_command("ApidocsOpen", apidocs_open, {})
-  vim.api.nvim_create_user_command("ApidocsSelect", function()
-    apidocs_open({use_ui_select = true})
-  end, {})
-  vim.api.nvim_create_user_command("ApidocsSearch", telescope.apidocs_search, {})
-  vim.api.nvim_create_user_command("ApidocsUninstall", function(args)
-    vim.system({"rm", "-Rf", common.data_folder() .. args.fargs[1]}, {text = true}, vim.schedule_wrap(function()
-      vim.notify("Apidocs: removed source " .. args.fargs[1])
-    end))
-  end, {
-    complete = function()
-      local docs_path = common.data_folder()
-      local fs = vim.uv.fs_scandir(docs_path)
-      local installed_docs = {}
-      while true do
-        local name, type = vim.uv.fs_scandir_next(fs)
-        if not name then break end
-        if type == 'directory' then
-          table.insert(installed_docs, name)
-        end
-      end
-      return installed_docs
-    end,
-    nargs = 1,
-  })
+local function apidocs_open(opts)
+	local picker = Config.picker
+	if opts and opts.picker then
+		picker = opts.picker
+	end
+	if picker == "snacks" then
+		snacks.apidocs_open(opts)
+		return
+	end
+	local docs_path = common.data_folder()
+	local fs = vim.uv.fs_scandir(docs_path)
+	local candidates = {}
+	local installed_docs = {}
+	while true do
+		local name, type = vim.uv.fs_scandir_next(fs)
+		if not name then
+			break
+		end
+		if type == "directory" then
+			if opts and opts.restrict_sources then
+				if vim.tbl_contains(opts.restrict_sources, name) then
+					table.insert(installed_docs, name)
+				end
+			else
+				table.insert(installed_docs, name)
+			end
+		end
+	end
+
+	if opts and opts.ensure_installed then
+		for _, source in ipairs(opts.ensure_installed) do
+			if not vim.tbl_contains(installed_docs, source) then
+				if slugs_to_mtimes == nil then
+					install.fetch_slugs_and_mtimes_and_then(function(slugs_to_mtimes)
+						install.apidoc_install(source, slugs_to_mtimes, function()
+							apidocs_open(opts, slugs_to_mtimes)
+						end)
+					end)
+					return
+				else
+					install.apidoc_install(source, slugs_to_mtimes, function()
+						apidocs_open(opts, slugs_to_mtimes)
+					end)
+					return
+				end
+			end
+		end
+	end
+
+	for _, name in ipairs(installed_docs) do
+		local fs2 = vim.uv.fs_scandir(docs_path .. "/" .. name)
+		while true do
+			local name2, type2 = vim.uv.fs_scandir_next(fs2)
+			if not name2 then
+				break
+			end
+			if type2 == "file" and vim.endswith(name2, ".html.md") then
+				local name_no_txt = name2:gsub("#.*$", "")
+				table.insert(candidates, { display = name .. "/" .. name_no_txt, path = name .. "/" .. name2 })
+			end
+		end
+	end
+
+	if picker == "ui_select" then
+		local display_list = vim.tbl_map(function(c)
+			return c.display
+		end, candidates)
+		local path_list = vim.tbl_map(function(c)
+			return c.path
+		end, candidates)
+		vim.ui.select(display_list, { prompt = "Pick a documentation to view" }, function(item, idx)
+			if item ~= nil then
+				common.open_doc_in_new_window(docs_path .. path_list[idx])
+			end
+		end)
+	else
+		telescope.apidocs_open(opts, slugs_to_mtimes, candidates)
+	end
+end
+
+local function apidocs_search(opts)
+	local picker = Config.picker
+	if opts and opts.picker then
+		picker = opts.picker
+	end
+	if picker == "ui_select" then
+		vim.notify("Apidocs: ui_select picker does not support search", vim.log.levels.ERROR)
+		return
+	end
+	if picker == "snacks" then
+		snacks.apidocs_search(opts)
+		return
+	end
+	if picker == "telescope" then
+		telescope.apidocs_search(opts)
+		return
+	end
+end
+
+local function set_config(opts)
+	Config = set_picker(opts)
+end
+
+local function setup(conf)
+	set_config(conf)
+	vim.api.nvim_create_user_command("ApidocsInstall", install.apidocs_install, {})
+	vim.api.nvim_create_user_command("ApidocsOpen", apidocs_open, {})
+	vim.api.nvim_create_user_command("ApidocsSearch", apidocs_search, {})
+	vim.api.nvim_create_user_command("ApidocsUninstall", function(args)
+		vim.system(
+			{ "rm", "-Rf", common.data_folder() .. args.fargs[1] },
+			{ text = true },
+			vim.schedule_wrap(function()
+				vim.notify("Apidocs: removed source " .. args.fargs[1])
+			end)
+		)
+	end, {
+		complete = function()
+			local docs_path = common.data_folder()
+			local fs = vim.uv.fs_scandir(docs_path)
+			local installed_docs = {}
+			while true do
+				local name, type = vim.uv.fs_scandir_next(fs)
+				if not name then
+					break
+				end
+				if type == "directory" then
+					table.insert(installed_docs, name)
+				end
+			end
+			return installed_docs
+		end,
+		nargs = 1,
+	})
 end
 
 return {
-  setup = setup,
-  apidocs_install = install.apidocs_install,
-  apidocs_open = apidocs_open,
-  apidocs_search = telescope.apidocs_search,
-  data_folder = common.data_folder,
-  open_doc_in_new_window = common.open_doc_in_new_window,
-  open_doc_in_cur_window = common.open_doc_in_cur_window,
-  load_doc_in_buffer = common.load_doc_in_buffer,
+	setup = setup,
+	config = Config,
+	apidocs_install = install.apidocs_install,
+	apidocs_open = apidocs_open,
+	apidocs_search = apidocs_search,
+	data_folder = common.data_folder,
+	open_doc_in_new_window = common.open_doc_in_new_window,
+	open_doc_in_cur_window = common.open_doc_in_cur_window,
+	load_doc_in_buffer = common.load_doc_in_buffer,
 }

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -6,168 +6,168 @@ local snacks = require("apidocs.snacks")
 Config = {}
 
 local function set_picker(opts)
-	if opts and (opts.picker == "snacks" or opts.picker == "telescope" or opts.picker == "ui_select") then
-		return opts
-	end
-	if not opts then
-		opts = {}
-	end
-	if package.loaded["snacks"] then
-		opts.picker = "snacks"
-		return opts
-	end
-	if package.loaded["telescope"] then
-		opts.picker = "telescope"
-		return opts
-	end
-	opts.picker = "ui_select"
-	return opts
+  if opts and (opts.picker == "snacks" or opts.picker == "telescope" or opts.picker == "ui_select") then
+    return opts
+  end
+  if not opts then
+    opts = {}
+  end
+  if package.loaded["snacks"] then
+    opts.picker = "snacks"
+    return opts
+  end
+  if package.loaded["telescope"] then
+    opts.picker = "telescope"
+    return opts
+  end
+  opts.picker = "ui_select"
+  return opts
 end
 
 local function apidocs_open(opts)
-	local picker = Config.picker
-	if opts and opts.picker then
-		picker = opts.picker
-	end
-	if picker == "snacks" then
-		snacks.apidocs_open(opts)
-		return
-	end
-	local docs_path = common.data_folder()
-	local fs = vim.uv.fs_scandir(docs_path)
-	local candidates = {}
-	local installed_docs = {}
-	while true do
-		local name, type = vim.uv.fs_scandir_next(fs)
-		if not name then
-			break
-		end
-		if type == "directory" then
-			if opts and opts.restrict_sources then
-				if vim.tbl_contains(opts.restrict_sources, name) then
-					table.insert(installed_docs, name)
-				end
-			else
-				table.insert(installed_docs, name)
-			end
-		end
-	end
+  local picker = Config.picker
+  if opts and opts.picker then
+    picker = opts.picker
+  end
+  if picker == "snacks" then
+    snacks.apidocs_open(opts)
+    return
+  end
+  local docs_path = common.data_folder()
+  local fs = vim.uv.fs_scandir(docs_path)
+  local candidates = {}
+  local installed_docs = {}
+  while true do
+    local name, type = vim.uv.fs_scandir_next(fs)
+    if not name then
+      break
+    end
+    if type == "directory" then
+      if opts and opts.restrict_sources then
+        if vim.tbl_contains(opts.restrict_sources, name) then
+          table.insert(installed_docs, name)
+        end
+      else
+        table.insert(installed_docs, name)
+      end
+    end
+  end
 
-	if opts and opts.ensure_installed then
-		for _, source in ipairs(opts.ensure_installed) do
-			if not vim.tbl_contains(installed_docs, source) then
-				if slugs_to_mtimes == nil then
-					install.fetch_slugs_and_mtimes_and_then(function(slugs_to_mtimes)
-						install.apidoc_install(source, slugs_to_mtimes, function()
-							apidocs_open(opts, slugs_to_mtimes)
-						end)
-					end)
-					return
-				else
-					install.apidoc_install(source, slugs_to_mtimes, function()
-						apidocs_open(opts, slugs_to_mtimes)
-					end)
-					return
-				end
-			end
-		end
-	end
+  if opts and opts.ensure_installed then
+    for _, source in ipairs(opts.ensure_installed) do
+      if not vim.tbl_contains(installed_docs, source) then
+        if slugs_to_mtimes == nil then
+          install.fetch_slugs_and_mtimes_and_then(function(slugs_to_mtimes)
+            install.apidoc_install(source, slugs_to_mtimes, function()
+              apidocs_open(opts, slugs_to_mtimes)
+            end)
+          end)
+          return
+        else
+          install.apidoc_install(source, slugs_to_mtimes, function()
+            apidocs_open(opts, slugs_to_mtimes)
+          end)
+          return
+        end
+      end
+    end
+  end
 
-	for _, name in ipairs(installed_docs) do
-		local fs2 = vim.uv.fs_scandir(docs_path .. "/" .. name)
-		while true do
-			local name2, type2 = vim.uv.fs_scandir_next(fs2)
-			if not name2 then
-				break
-			end
-			if type2 == "file" and vim.endswith(name2, ".html.md") then
-				local name_no_txt = name2:gsub("#.*$", "")
-				table.insert(candidates, { display = name .. "/" .. name_no_txt, path = name .. "/" .. name2 })
-			end
-		end
-	end
+  for _, name in ipairs(installed_docs) do
+    local fs2 = vim.uv.fs_scandir(docs_path .. "/" .. name)
+    while true do
+      local name2, type2 = vim.uv.fs_scandir_next(fs2)
+      if not name2 then
+        break
+      end
+      if type2 == "file" and vim.endswith(name2, ".html.md") then
+        local name_no_txt = name2:gsub("#.*$", "")
+        table.insert(candidates, { display = name .. "/" .. name_no_txt, path = name .. "/" .. name2 })
+      end
+    end
+  end
 
-	if picker == "ui_select" then
-		local display_list = vim.tbl_map(function(c)
-			return c.display
-		end, candidates)
-		local path_list = vim.tbl_map(function(c)
-			return c.path
-		end, candidates)
-		vim.ui.select(display_list, { prompt = "Pick a documentation to view" }, function(item, idx)
-			if item ~= nil then
-				common.open_doc_in_new_window(docs_path .. path_list[idx])
-			end
-		end)
-	else
-		telescope.apidocs_open(opts, slugs_to_mtimes, candidates)
-	end
+  if picker == "ui_select" then
+    local display_list = vim.tbl_map(function(c)
+      return c.display
+    end, candidates)
+    local path_list = vim.tbl_map(function(c)
+      return c.path
+    end, candidates)
+    vim.ui.select(display_list, { prompt = "Pick a documentation to view" }, function(item, idx)
+      if item ~= nil then
+        common.open_doc_in_new_window(docs_path .. path_list[idx])
+      end
+    end)
+  else
+    telescope.apidocs_open(opts, slugs_to_mtimes, candidates)
+  end
 end
 
 local function apidocs_search(opts)
-	local picker = Config.picker
-	if opts and opts.picker then
-		picker = opts.picker
-	end
-	if picker == "ui_select" then
-		vim.notify("Apidocs: ui_select picker does not support search", vim.log.levels.ERROR)
-		return
-	end
-	if picker == "snacks" then
-		snacks.apidocs_search(opts)
-		return
-	end
-	if picker == "telescope" then
-		telescope.apidocs_search(opts)
-		return
-	end
+  local picker = Config.picker
+  if opts and opts.picker then
+    picker = opts.picker
+  end
+  if picker == "ui_select" then
+    vim.notify("Apidocs: ui_select picker does not support search", vim.log.levels.ERROR)
+    return
+  end
+  if picker == "snacks" then
+    snacks.apidocs_search(opts)
+    return
+  end
+  if picker == "telescope" then
+    telescope.apidocs_search(opts)
+    return
+  end
 end
 
 local function set_config(opts)
-	Config = set_picker(opts)
+  Config = set_picker(opts)
 end
 
 local function setup(conf)
-	set_config(conf)
-	vim.api.nvim_create_user_command("ApidocsInstall", install.apidocs_install, {})
-	vim.api.nvim_create_user_command("ApidocsOpen", apidocs_open, {})
-	vim.api.nvim_create_user_command("ApidocsSearch", apidocs_search, {})
-	vim.api.nvim_create_user_command("ApidocsUninstall", function(args)
-		vim.system(
-			{ "rm", "-Rf", common.data_folder() .. args.fargs[1] },
-			{ text = true },
-			vim.schedule_wrap(function()
-				vim.notify("Apidocs: removed source " .. args.fargs[1])
-			end)
-		)
-	end, {
-		complete = function()
-			local docs_path = common.data_folder()
-			local fs = vim.uv.fs_scandir(docs_path)
-			local installed_docs = {}
-			while true do
-				local name, type = vim.uv.fs_scandir_next(fs)
-				if not name then
-					break
-				end
-				if type == "directory" then
-					table.insert(installed_docs, name)
-				end
-			end
-			return installed_docs
-		end,
-		nargs = 1,
-	})
+  set_config(conf)
+  vim.api.nvim_create_user_command("ApidocsInstall", install.apidocs_install, {})
+  vim.api.nvim_create_user_command("ApidocsOpen", apidocs_open, {})
+  vim.api.nvim_create_user_command("ApidocsSearch", apidocs_search, {})
+  vim.api.nvim_create_user_command("ApidocsUninstall", function(args)
+    vim.system(
+      { "rm", "-Rf", common.data_folder() .. args.fargs[1] },
+      { text = true },
+      vim.schedule_wrap(function()
+        vim.notify("Apidocs: removed source " .. args.fargs[1])
+      end)
+    )
+  end, {
+    complete = function()
+      local docs_path = common.data_folder()
+      local fs = vim.uv.fs_scandir(docs_path)
+      local installed_docs = {}
+      while true do
+        local name, type = vim.uv.fs_scandir_next(fs)
+        if not name then
+          break
+        end
+        if type == "directory" then
+          table.insert(installed_docs, name)
+        end
+      end
+      return installed_docs
+    end,
+    nargs = 1,
+  })
 end
 
 return {
-	setup = setup,
-	config = Config,
-	apidocs_install = install.apidocs_install,
-	apidocs_open = apidocs_open,
-	apidocs_search = apidocs_search,
-	data_folder = common.data_folder,
-	open_doc_in_new_window = common.open_doc_in_new_window,
-	open_doc_in_cur_window = common.open_doc_in_cur_window,
-	load_doc_in_buffer = common.load_doc_in_buffer,
+  setup = setup,
+  config = Config,
+  apidocs_install = install.apidocs_install,
+  apidocs_open = apidocs_open,
+  apidocs_search = apidocs_search,
+  data_folder = common.data_folder,
+  open_doc_in_new_window = common.open_doc_in_new_window,
+  open_doc_in_cur_window = common.open_doc_in_cur_window,
+  load_doc_in_buffer = common.load_doc_in_buffer,
 }

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -20,12 +20,19 @@ local common_win_options = {
   },
 }
 
-local function get_data_dir(opts)
+local function get_data_dirs(opts)
   local data_dir = common.data_folder()
-  if opts and opts.source then
-    data_dir = data_dir .. opts.source .. "/"
+  if not (opts and opts.restrict_sources) then
+    return { data_dir }
   end
-  return data_dir
+  local dirs = {}
+  for _, source in ipairs(opts.restrict_sources) do
+    local dir = data_dir .. source .. "/"
+    if vim.fn.isdirectory(dir) == 1 then
+      table.insert(dirs, dir)
+    end
+  end
+  return dirs
 end
 
 local function format_entries(item, picker)
@@ -75,7 +82,7 @@ local function apidocs_open(opts)
   Snacks.picker.files({
     layout = common_layout_options,
     win = common_win_options,
-    dirs = { get_data_dir(opts) },
+    dirs = get_data_dirs(opts),
     ft = { "markdown", "md" },
     confirm = function(picker, item)
       require("apidocs").open_doc_in_new_window(item.file)
@@ -88,7 +95,7 @@ local function apidocs_search(opts)
   Snacks.picker.grep({
     layout = common_layout_options,
     win = common_win_options,
-    dirs = { get_data_dir(opts) },
+    dirs = get_data_dirs(opts),
     ft = { "markdown", "md" },
     confirm = function(picker, item)
       require("apidocs").open_doc_in_new_window(item.file)

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -28,6 +28,7 @@ local function get_data_dir(opts)
 end
 
 local function format_entries(item, picker)
+	vim.notify(vim.inspect(item), vim.log.levels.DEBUG, { title = "Snacks" })
 	local parts = vim.split(item.file, "/")
 	-- take the last part and set it as the text
 	local folder = parts[#parts - 1]
@@ -90,7 +91,7 @@ local function apidocs_search(opts)
 		dirs = { get_data_dir(opts) },
 		ft = { "markdown", "md" },
 		confirm = function(picker, item)
-			require("apidocs").search_doc_in_new_window(item.file)
+			require("apidocs").open_doc_in_new_window(item.file)
 		end,
 		format = format_entries,
 	})

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -59,22 +59,11 @@ local function format_entries(item, picker)
     },
   }
   local fileNameParts = vim.split(filename, "#")
-  -- loop through the parts and add them to the new_item
-  for i = 1, #fileNameParts do
-    local part = fileNameParts[i]
-    new_item[#new_item + 1] = {
-      part,
-      "SnacksPickerFile",
-      field = "file",
-    }
-    if i < #fileNameParts then
-      new_item[#new_item + 1] = {
-        " > ",
-        "SnacksPickerDelim",
-        field = "file",
-      }
-    end
-  end
+  new_item[#new_item + 1] = {
+    fileNameParts[1],
+    "SnacksPickerFile",
+    field = "file",
+  }
   return new_item
 end
 

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -29,7 +29,6 @@ local function get_data_dir(opts)
 end
 
 local function format_entries(item, picker)
-	vim.notify(vim.inspect(item), vim.log.levels.DEBUG, { title = "Snacks" })
 	local parts = vim.split(item.file, "/")
 	-- take the last part and set it as the text
 	local folder = parts[#parts - 1]

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -1,0 +1,102 @@
+local common = require("apidocs.common")
+local Snacks = require("snacks")
+
+local common_layout_options = {
+	preview = true,
+	preset = "telescope",
+}
+local common_win_options = {
+	preview = {
+		wo = {
+			number = true,
+			relativenumber = false,
+			signcolumn = "no",
+			conceallevel = 2,
+			concealcursor = "n",
+			winfixbuf = true,
+			list = false,
+			wrap = false,
+		},
+	},
+}
+
+local function get_data_dir(opts)
+	local data_dir = common.data_folder()
+	if opts and opts.source then
+		data_dir = data_dir .. opts.source .. "/"
+	end
+end
+
+local function format_entries(item, picker)
+	local parts = vim.split(item.file, "/")
+	-- take the last part and set it as the text
+	local folder = parts[#parts - 1]
+	local filename = parts[#parts]
+	local filetype = vim.split(folder, "~")[1]
+	local icon, hl = Snacks.util.icon(filetype, "filetype", {
+		fallback = picker.opts.icons.files,
+	})
+	icon = Snacks.picker.util.align(icon, picker.opts.formatters.file.icon_width or 2)
+	filename = filename:gsub("%.html%.md$", "")
+	local new_item = {
+		{
+			icon,
+			hl,
+			virtual = true,
+		},
+		{
+			folder .. " | ",
+			"SnacksPickerSpecial",
+			field = "file",
+		},
+	}
+	local fileNameParts = vim.split(filename, "#")
+	-- loop through the parts and add them to the new_item
+	for i = 1, #fileNameParts do
+		local part = fileNameParts[i]
+		new_item[#new_item + 1] = {
+			part,
+			"SnacksPickerFile",
+			field = "file",
+		}
+		if i < #fileNameParts then
+			new_item[#new_item + 1] = {
+				" > ",
+				"SnacksPickerDelim",
+				field = "file",
+			}
+		end
+	end
+	return new_item
+end
+
+local function apidocs_open(opts)
+	Snacks.picker.files({
+		layout = common_layout_options,
+		win = common_win_options,
+		dirs = { get_data_dir(opts) },
+		ft = { "markdown", "md" },
+		confirm = function(picker, item)
+			require("apidocs").open_doc_in_new_window(item.file)
+		end,
+		format = format_entries,
+	})
+end
+
+local function apidocs_search(opts)
+	Snacks.picker.grep({
+		layout = common_layout_options,
+		win = common_win_options,
+		dirs = { get_data_dir(opts) },
+		ft = { "markdown", "md" },
+		confirm = function(picker, item)
+			require("apidocs").search_doc_in_new_window(item.file)
+		end,
+		format = format_entries,
+	})
+end
+
+return {
+	apidocs_open = apidocs_open,
+	apidocs_search = apidocs_search,
+}

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -2,102 +2,102 @@ local common = require("apidocs.common")
 local Snacks = require("snacks")
 
 local common_layout_options = {
-	preview = true,
-	preset = "telescope",
+  preview = true,
+  preset = "telescope",
 }
 local common_win_options = {
-	preview = {
-		wo = {
-			number = true,
-			relativenumber = false,
-			signcolumn = "no",
-			conceallevel = 2,
-			concealcursor = "n",
-			winfixbuf = true,
-			list = false,
-			wrap = false,
-		},
-	},
+  preview = {
+    wo = {
+      number = true,
+      relativenumber = false,
+      signcolumn = "no",
+      conceallevel = 2,
+      concealcursor = "n",
+      winfixbuf = true,
+      list = false,
+      wrap = false,
+    },
+  },
 }
 
 local function get_data_dir(opts)
-	local data_dir = common.data_folder()
-	if opts and opts.source then
-		data_dir = data_dir .. opts.source .. "/"
-	end
-	return data_dir
+  local data_dir = common.data_folder()
+  if opts and opts.source then
+    data_dir = data_dir .. opts.source .. "/"
+  end
+  return data_dir
 end
 
 local function format_entries(item, picker)
-	local parts = vim.split(item.file, "/")
-	-- take the last part and set it as the text
-	local folder = parts[#parts - 1]
-	local filename = parts[#parts]
-	local filetype = vim.split(folder, "~")[1]
-	local icon, hl = Snacks.util.icon(filetype, "filetype", {
-		fallback = picker.opts.icons.files,
-	})
-	icon = Snacks.picker.util.align(icon, picker.opts.formatters.file.icon_width or 2)
-	filename = filename:gsub("%.html%.md$", "")
-	local new_item = {
-		{
-			icon,
-			hl,
-			virtual = true,
-		},
-		{
-			folder .. " | ",
-			"SnacksPickerSpecial",
-			field = "file",
-		},
-	}
-	local fileNameParts = vim.split(filename, "#")
-	-- loop through the parts and add them to the new_item
-	for i = 1, #fileNameParts do
-		local part = fileNameParts[i]
-		new_item[#new_item + 1] = {
-			part,
-			"SnacksPickerFile",
-			field = "file",
-		}
-		if i < #fileNameParts then
-			new_item[#new_item + 1] = {
-				" > ",
-				"SnacksPickerDelim",
-				field = "file",
-			}
-		end
-	end
-	return new_item
+  local parts = vim.split(item.file, "/")
+  -- take the last part and set it as the text
+  local folder = parts[#parts - 1]
+  local filename = parts[#parts]
+  local filetype = vim.split(folder, "~")[1]
+  local icon, hl = Snacks.util.icon(filetype, "filetype", {
+    fallback = picker.opts.icons.files,
+  })
+  icon = Snacks.picker.util.align(icon, picker.opts.formatters.file.icon_width or 2)
+  filename = filename:gsub("%.html%.md$", "")
+  local new_item = {
+    {
+      icon,
+      hl,
+      virtual = true,
+    },
+    {
+      folder .. " | ",
+      "SnacksPickerSpecial",
+      field = "file",
+    },
+  }
+  local fileNameParts = vim.split(filename, "#")
+  -- loop through the parts and add them to the new_item
+  for i = 1, #fileNameParts do
+    local part = fileNameParts[i]
+    new_item[#new_item + 1] = {
+      part,
+      "SnacksPickerFile",
+      field = "file",
+    }
+    if i < #fileNameParts then
+      new_item[#new_item + 1] = {
+        " > ",
+        "SnacksPickerDelim",
+        field = "file",
+      }
+    end
+  end
+  return new_item
 end
 
 local function apidocs_open(opts)
-	Snacks.picker.files({
-		layout = common_layout_options,
-		win = common_win_options,
-		dirs = { get_data_dir(opts) },
-		ft = { "markdown", "md" },
-		confirm = function(picker, item)
-			require("apidocs").open_doc_in_new_window(item.file)
-		end,
-		format = format_entries,
-	})
+  Snacks.picker.files({
+    layout = common_layout_options,
+    win = common_win_options,
+    dirs = { get_data_dir(opts) },
+    ft = { "markdown", "md" },
+    confirm = function(picker, item)
+      require("apidocs").open_doc_in_new_window(item.file)
+    end,
+    format = format_entries,
+  })
 end
 
 local function apidocs_search(opts)
-	Snacks.picker.grep({
-		layout = common_layout_options,
-		win = common_win_options,
-		dirs = { get_data_dir(opts) },
-		ft = { "markdown", "md" },
-		confirm = function(picker, item)
-			require("apidocs").open_doc_in_new_window(item.file)
-		end,
-		format = format_entries,
-	})
+  Snacks.picker.grep({
+    layout = common_layout_options,
+    win = common_win_options,
+    dirs = { get_data_dir(opts) },
+    ft = { "markdown", "md" },
+    confirm = function(picker, item)
+      require("apidocs").open_doc_in_new_window(item.file)
+    end,
+    format = format_entries,
+  })
 end
 
 return {
-	apidocs_open = apidocs_open,
-	apidocs_search = apidocs_search,
+  apidocs_open = apidocs_open,
+  apidocs_search = apidocs_search,
 }

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -25,6 +25,7 @@ local function get_data_dir(opts)
 	if opts and opts.source then
 		data_dir = data_dir .. opts.source .. "/"
 	end
+	return data_dir
 end
 
 local function format_entries(item, picker)


### PR DESCRIPTION
Along with Snacks picker integration, this PR implements the following changes:

1. Configuration Options. Currently, there is only one option to pass: `picker` with valid values:
  a. `ui_select`
  b. `telescope`
  c. `snacks`
2. Auto-detect picker if not explicitly set in the config.
3. Remove `ApidocsSelect` since it is redundant with the picker auto-detect.

Screenshots for `ApidocsOpen` and `ApidocsSearch` respectively:

<img width="2554" alt="Screenshot 2025-05-05 at 5 58 02 PM" src="https://github.com/user-attachments/assets/44186adf-3ed3-4b1e-b71f-a45ca23f19da" />
<img width="2554" alt="Screenshot 2025-05-05 at 5 58 56 PM" src="https://github.com/user-attachments/assets/8c6799b5-4556-4f17-b53f-31836f05a4f3" />