### PR TITLE
Install docs on plugin load; partial matching for restrict_sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ return {
   end,
   keys = {
     { '<leader>sad', '<cmd>ApidocsOpen<cr>', desc = 'Search Api Doc' },
+    {
+      '<leader>sac',
+      function()
+        local lang = vim.bo.filetype
+        require("apidocs").apidocs_search({ restrict_sources = { lang } })
+      end,
+      desc = 'Search Api Doc (restricted to current file type)'
+    },
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,11 +44,20 @@ return {
     'nvim-telescope/telescope.nvim', -- or, 'folke/snacks.nvim'
   },
   cmd = { 'ApidocsSearch', 'ApidocsInstall', 'ApidocsOpen', 'ApidocsSelect', 'ApidocsUninstall' },
+  -- If using ensure_installed (see below), uncomment the next line to trigger the
+  -- installation when Neovim is opened
+  -- lazy = false
   config = function()
-    require('apidocs').setup()
-    -- Picker will be auto-detected. To select a picker of your choice explicitly you can set picker by the configuration option 'picker':
-    -- require('apidocs').setup({picker = "snacks"})
-    -- Possible options are 'ui_select', 'telescope', and 'snacks'
+    local opts = {
+      -- Picker will be auto-detected. To select a picker of your choice explicitly you can set picker by the configuration option 'picker':
+      -- Possible options are 'ui_select', 'telescope', and 'snacks'
+      picker = "telescope",
+      -- Use the below to make sure documentations for your languages are installed
+      -- Note: best used with `lazy = false` (see above)
+      -- ensure_installed = { "lua~5.4" }
+
+    }
+    require('apidocs').setup(opts)
   end,
   keys = {
     { '<leader>sad', '<cmd>ApidocsOpen<cr>', desc = 'Search Api Doc' },

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -5,6 +5,9 @@ Config = {}
 
 local function get_installed_docs(fs, opts)
   local installed_docs = {}
+  if fs == nil then
+    return installed_docs
+  end
   while true do
     local name, type = vim.uv.fs_scandir_next(fs)
     if not name then

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -12,8 +12,10 @@ local function get_installed_docs(fs, opts)
     end
     if type == "directory" then
       if opts and opts.restrict_sources then
-        if vim.tbl_contains(opts.restrict_sources, name) then
-          table.insert(installed_docs, name)
+        for _, source in ipairs(opts.restrict_sources) do
+          if name:match("^" .. source) then
+            table.insert(installed_docs, name)
+          end
         end
       else
         table.insert(installed_docs, name)

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -26,10 +26,17 @@ local function get_data_dirs(opts)
     return { data_dir }
   end
   local dirs = {}
+  local install_dirs = vim.fn.readdir(data_dir)
   for _, source in ipairs(opts.restrict_sources) do
-    local dir = data_dir .. source .. "/"
-    if vim.fn.isdirectory(dir) == 1 then
-      table.insert(dirs, dir)
+    for _, entry in ipairs(install_dirs) do
+      if vim.fn.isdirectory(data_dir .. entry) == 1 then
+        if entry == source then
+          table.insert(dirs, data_dir .. entry .. "/")
+        elseif entry:match("^" .. source) then
+          -- no exact match found, check for a partial match
+          table.insert(dirs, data_dir .. entry .. "/")
+        end
+      end
     end
   end
   return dirs


### PR DESCRIPTION
This plugin contains two commits that add minor enhancements. Both of these changes are non-breaking. If you'd like any alterations feel free to let me know.

Also, note that the majority of line changes to `telescope.lua` in [#ca1e5d6](https://github.com/chunned/apidocs.nvim/commit/ca1e5d6a4bfc4db20045c621e76610b8929f3e87) are just whitespace shenanigans. The lines that were actually changed were lines 75-97.

# Install `ensure_installed` docs on plugin load

Previously, `ensure_installed` was only checked during the call to `apidocs_open()`. Now, if the user sets this value in the plugin config, the docs can be automatically installed as soon as the plugin loads. This is showcased in the added example to the README, which also sets `lazy = false` so that the plugin always loads as soon as Neovim is opened:

```lua
return {
  {
    -- "emmanueltouzery/apidocs.nvim",
    lazy = false,
    ...
    config = function()
      local opts = {
        ensure_installed = { "python~3.13", "lua~5.4", "rust", "ansible", "go" },
        ...
      }
      require("apidocs").setup(opts)
    end,
    ...
  }
}
```

# Partial matching for `restrict_sources`

Added partial string matching for `restrict_sources`. Previously, the exact directory name had to be entered, e.g. `python~3.13` rather than just `python`. With the new approach, if `restrict_sources` contains a value `python`, any directories starting with `python` will be considered valid. The motivation for this is demonstrated in the README example - we can now automatically restrict the sources for the language of the current file, and we won't have issues if the language docs have the version in their name:

```lua
...
keys = {
  {
    "<leader>aps",
	function()
	  local lang = vim.bo.filetype
	  require("apidocs").apidocs_search({ restrict_sources = { lang } })
	end,
	desc = "Apidocs: Search, restricted to current file language"			
  },
},
...
```