### PR TITLE
Properly display Class#name entries

### DIFF
--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -101,7 +101,7 @@ local function apidocs_open_only()
         break
       end
       if type2 == "file" and vim.endswith(name2, ".html.md") then
-        local name_no_txt = name2:gsub("#.*$", "")
+        local name_no_txt = common.filename_to_display(name2)
         table.insert(candidates, { display = name .. "/" .. name_no_txt, path = name .. "/" .. name2 })
       end
     end

--- a/lua/apidocs/common.lua
+++ b/lua/apidocs/common.lua
@@ -104,6 +104,19 @@ local function open_doc_in_new_window(docs_path)
   vim.api.nvim_buf_set_name(0, desc)
 end
 
+-- convert filename to picker display string
+local function filename_to_display(filename)
+  local components = vim.split(filename, "#")
+  local display = components[1]
+  -- little hack: In some languages the filename contains "Class#method", which messes
+  -- up our "#" - separated schema. So if there are 4 "components" in the filename,
+  -- the first two (separated by "#") have to be the actual key to display.
+  if(#components == 4) then
+    display = display .. "#" .. components[2]
+  end
+  return display
+end
+
 
 return {
   data_folder = data_folder,

--- a/lua/apidocs/telescope.lua
+++ b/lua/apidocs/telescope.lua
@@ -86,16 +86,16 @@ local function apidocs_search(opts)
   local default_entry_maker = make_entry.gen_from_vimgrep()
   local function entry_maker(entry)
     local r = default_entry_maker(entry)
-      r.display = function(entry)
-        local entry_components = vim.split(entry.filename:sub(#folder+1), "#")
-        local source_length = entry_components[1]:find("/")
-        local hl_group = {
-          { {0, source_length}, "TelescopeResultsTitle"},
-          { {source_length, #entry_components[1]}, "TelescopeResultsMethod" },
-          { {#entry_components[1], #entry_components[1] + #(tostring(entry.lnum))+2}, "TelescopeResultsLineNr" },
-        }
-        return string.format("%s:%d: %s", entry_components[1], entry.lnum, entry.text), hl_group
-      end
+    r.display = function(entry)
+      local display = common.filename_to_display(entry.filename:sub(#folder+1))
+      local source_length = display:find("/")
+      local hl_group = {
+        { {0, source_length}, "TelescopeResultsTitle"},
+        { {source_length, #display}, "TelescopeResultsMethod" },
+        { {#display, #display + #(tostring(entry.lnum))+2}, "TelescopeResultsLineNr" },
+      }
+      return string.format("%s:%d: %s", display, entry.lnum, entry.text), hl_group
+    end
     return r
   end
 


### PR DESCRIPTION
Workaround for #11

This looks whether the doc (entry) filename contains 4 components after being split on `#`. If so, it considers the first 2 components to be the "Class" and "Method" parts respectively and joins them with "#" for display in the picker.

This way the current filename encoding still works and `Class#method` entries are still displayed correctly.

I'm not sure whether that's feasible - the handling in `common.lua`, `#open_doc_in_cur_window()` hints at a potential problem, but it *should* be fine.