### PR TITLE
Improving installing of new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This plugin requires:
 - ripgrep
 - curl
 - linux and probably OSX. Windows will not work, except maybe using WSL
+- treesitter for html and markdown_inline, easiest way to get them is via [treesitter.nvim](https://github.com/nvim-treesitter/nvim-treesitter) plugin
 
 ## Lazy package manager setup
 
@@ -41,6 +42,7 @@ This plugin requires:
 return {
   'emmanueltouzery/apidocs.nvim',
   dependencies = {
+    'nvim-treesitter/nvim-treesitter',
     'nvim-telescope/telescope.nvim', -- or, 'folke/snacks.nvim'
   },
   cmd = { 'ApidocsSearch', 'ApidocsInstall', 'ApidocsOpen', 'ApidocsSelect', 'ApidocsUninstall' },

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -22,6 +22,28 @@ local function set_picker(opts)
   return opts
 end
 
+local function install_treesitter(lang)
+  if package.loaded["nvim-treesitter"] then
+    vim.cmd("TSInstall " .. lang)
+  else
+    vim.api.nvim_echo({
+      { "treesitter parser for " .. lang .. "is not installed" },
+      { "ApidocsInstall will not work properly until it is" },
+    }, true, { err = true })
+  end
+end
+
+
+local function ensure_treesitter_dependency()
+  local language = vim.treesitter.language
+  if not language.add('html') then
+    install_treesitter('html')
+  end
+  if not language.add('markdown_inline') then
+    install_treesitter('markdown_inline')
+  end
+end
+
 local function get_installed_docs(opts)
   local docs_path = common.data_folder()
   local fs = vim.uv.fs_scandir(docs_path)
@@ -159,6 +181,9 @@ end
 
 local function setup(conf)
   set_config(conf)
+
+  ensure_treesitter_dependency()
+
   vim.api.nvim_create_user_command("ApidocsInstall", install.apidocs_install, {})
   vim.api.nvim_create_user_command("ApidocsOpen", apidocs_open, {})
   vim.api.nvim_create_user_command("ApidocsSearch", apidocs_search, {})

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -28,7 +28,7 @@ local function install_treesitter(lang)
     vim.cmd("TSInstall " .. lang)
   else
     vim.api.nvim_echo({
-      { "treesitter parser for " .. lang .. "is not installed" },
+      { "tree-sitter parser for " .. lang .. "is not installed" },
       { "ApidocsInstall will not work properly until it is" },
     }, true, { err = true })
   end
@@ -100,6 +100,8 @@ local function ensure_install(languages)
 end
 
 local function apidocs_install(args)
+	print("Yes")
+	vim.notify("Correct function called, args: "..args.nargs)
 	if args.nargs == 1 then
 		local installed_docs = get_installed_docs()
 		local to_install = args.fargs[1]

--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -1,6 +1,5 @@
 local common = require("apidocs.common")
 local install = require("apidocs.install")
-local telescope = require("apidocs.telescope")
 
 Config = {}
 
@@ -100,9 +99,7 @@ local function ensure_install(languages)
 end
 
 local function apidocs_install(args)
-	print("Yes")
-	vim.notify("Correct function called, args: "..args.nargs)
-	if args.nargs == 1 then
+	if args.nargs and args.nargs == 1 then
 		local installed_docs = get_installed_docs()
 		local to_install = args.fargs[1]
 
@@ -113,9 +110,14 @@ local function apidocs_install(args)
 			return
 		end
 
-  elseif args.nargs == 0 then
+  elseif args.nargs and args.nargs > 1 then
+		vim.notify("Apidocs: too many arguments", vim.log.levels.ERROR)
+	else
 		if Config.picker == "telescope" then
-			telescope.apidocs_install()
+			require("apidocs.telescope").apidocs_install()
+			return
+		elseif Config.picker == "snacks" then
+			require("apidocs.snacks").apidocs_install()
 			return
 		else
 			install.apidocs_install()
@@ -123,7 +125,6 @@ local function apidocs_install(args)
 		end
 	end
 end
-
 
 -- ignore the ensure_installed option, that's handled by apidocs_open
 local function apidocs_open_only()

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -93,7 +93,36 @@ local function apidocs_search(opts)
   })
 end
 
+local function apidocs_install()
+  -- might not work, have no way of testing it
+  local install = require("apidocs.install")
+
+  if vim.fn.executable("elinks") ~= 1 or vim.fn.executable("rg") ~= 1 or vim.fn.executable("find") ~= 1 then
+    print("The 'elinks', 'rg' and 'find' programs must be installed to proceed, refusing to run.")
+  else
+    install.fetch_slugs_and_mtimes_and_then(function (slugs_to_mtimes)
+      local keys = vim.tbl_keys(slugs_to_mtimes)
+      table.sort(keys)
+      Snacks.picker({
+        title = "API docs install",
+        layout = common_layout_options,
+        win = common_win_options,
+        items = keys,
+        on_select = function(choice)
+          if choice == nil then
+            return
+          end
+          install.apidoc_install(choice[1], slugs_to_mtimes)
+        end,
+        format = format_entries,
+      })
+
+    end)
+  end
+end
+
 return {
   apidocs_open = apidocs_open,
   apidocs_search = apidocs_search,
+  apidocs_install = apidocs_install,
 }

--- a/lua/apidocs/telescope.lua
+++ b/lua/apidocs/telescope.lua
@@ -150,8 +150,8 @@ local function apidocs_search(opts)
 end
 
 local function apidocs_install()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
+  local pickers = require("telescope.pickers")
+  local finders = require("telescope.finders")
   local action_state = require("telescope.actions.state")
   local actions = require("telescope.actions")
   local conf = require("telescope.config").values
@@ -172,6 +172,10 @@ local function apidocs_install()
           local function on_select()
             local choice = action_state.get_selected_entry()
             actions.close(prompt_bufnr)
+
+            if choice == nil then
+              return
+            end
             install.apidoc_install(choice[1], slugs_to_mtimes)
           end
 

--- a/lua/apidocs/telescope.lua
+++ b/lua/apidocs/telescope.lua
@@ -149,7 +149,7 @@ local function apidocs_search(opts)
   })
 end
 
-local function apidocs_install(opts)
+local function apidocs_install()
   local pickers = require "telescope.pickers"
   local finders = require "telescope.finders"
   local action_state = require("telescope.actions.state")
@@ -162,28 +162,17 @@ local function apidocs_install(opts)
     install.fetch_slugs_and_mtimes_and_then(function (slugs_to_mtimes)
       local keys = vim.tbl_keys(slugs_to_mtimes)
       table.sort(keys)
-
-      local function entry_maker(entry)
-        return {
-          value = docs_path .. entry.path,
-          ordinal = entry.display,
-          display = entry.display,
-          contents = entry.display,
-        }
-      end
-
       pickers.new({}, {
         prompt_title = "API docs install",
         finder = finders.new_table {
           results = keys,
-          -- entry_maker = entry_maker
         },
         sorter = conf.generic_sorter({}),
         attach_mappings = function(prompt_bufnr, map)
           local function on_select()
-            local selection = action_state.get_selected_entry()
+            local choice = action_state.get_selected_entry()
             actions.close(prompt_bufnr)
-            print("You picked: " .. selection[1])
+            install.apidoc_install(choice, slugs_to_mtimes)
           end
 
           map("i", "<CR>", on_select)

--- a/lua/apidocs/telescope.lua
+++ b/lua/apidocs/telescope.lua
@@ -162,39 +162,39 @@ local function apidocs_install(opts)
     install.fetch_slugs_and_mtimes_and_then(function (slugs_to_mtimes)
       local keys = vim.tbl_keys(slugs_to_mtimes)
       table.sort(keys)
-      printTable(keys)
+
+      local function entry_maker(entry)
+        return {
+          value = docs_path .. entry.path,
+          ordinal = entry.display,
+          display = entry.display,
+          contents = entry.display,
+        }
+      end
+
+      pickers.new({}, {
+        prompt_title = "API docs install",
+        finder = finders.new_table {
+          results = keys,
+          -- entry_maker = entry_maker
+        },
+        sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+          local function on_select()
+            local selection = action_state.get_selected_entry()
+            actions.close(prompt_bufnr)
+            print("You picked: " .. selection[1])
+          end
+
+          map("i", "<CR>", on_select)
+          map("n", "<CR>", on_select)
+          return true
+        end,
+      }):find()
     end)
   end
 
 
-  local function entry_maker(entry)
-    return {
-      value = docs_path .. entry.path,
-      ordinal = entry.display,
-      display = entry.display,
-      contents = entry.display,
-    }
-  end
-
-  -- pickers.new({}, {
-  --   prompt_title = "API docs install",
-  --   finder = finders.new_table {
-  --     results = keys,
-  --     -- entry_maker = entry_maker
-  --   },
-  --   sorter = conf.generic_sorter({}),
-  --   attach_mappings = function(prompt_bufnr, map)
-  --     local function on_select()
-  --       local selection = action_state.get_selected_entry()
-  --       actions.close(prompt_bufnr)
-  --       print("You picked: " .. selection[1])
-  --     end
-  --
-  --     map("i", "<CR>", on_select)
-  --     map("n", "<CR>", on_select)
-  --     return true
-  --   end,
-  -- }):find()
 end
 
 

--- a/lua/apidocs/telescope.lua
+++ b/lua/apidocs/telescope.lua
@@ -172,7 +172,7 @@ local function apidocs_install()
           local function on_select()
             local choice = action_state.get_selected_entry()
             actions.close(prompt_bufnr)
-            install.apidoc_install(choice, slugs_to_mtimes)
+            install.apidoc_install(choice[1], slugs_to_mtimes)
           end
 
           map("i", "<CR>", on_select)

--- a/lua/apidocs/telescope.lua
+++ b/lua/apidocs/telescope.lua
@@ -149,7 +149,57 @@ local function apidocs_search(opts)
   })
 end
 
+local function apidocs_install(opts)
+  local pickers = require "telescope.pickers"
+  local finders = require "telescope.finders"
+  local action_state = require("telescope.actions.state")
+  local actions = require("telescope.actions")
+  local conf = require("telescope.config").values
+
+  if vim.fn.executable("elinks") ~= 1 or vim.fn.executable("rg") ~= 1 or vim.fn.executable("find") ~= 1 then
+    print("The 'elinks', 'rg' and 'find' programs must be installed to proceed, refusing to run.")
+  else
+    install.fetch_slugs_and_mtimes_and_then(function (slugs_to_mtimes)
+      local keys = vim.tbl_keys(slugs_to_mtimes)
+      table.sort(keys)
+      printTable(keys)
+    end)
+  end
+
+
+  local function entry_maker(entry)
+    return {
+      value = docs_path .. entry.path,
+      ordinal = entry.display,
+      display = entry.display,
+      contents = entry.display,
+    }
+  end
+
+  -- pickers.new({}, {
+  --   prompt_title = "API docs install",
+  --   finder = finders.new_table {
+  --     results = keys,
+  --     -- entry_maker = entry_maker
+  --   },
+  --   sorter = conf.generic_sorter({}),
+  --   attach_mappings = function(prompt_bufnr, map)
+  --     local function on_select()
+  --       local selection = action_state.get_selected_entry()
+  --       actions.close(prompt_bufnr)
+  --       print("You picked: " .. selection[1])
+  --     end
+  --
+  --     map("i", "<CR>", on_select)
+  --     map("n", "<CR>", on_select)
+  --     return true
+  --   end,
+  -- }):find()
+end
+
+
 return {
   apidocs_open = apidocs_open,
   apidocs_search = apidocs_search,
+  apidocs_install = apidocs_install,
 }

--- a/parser/.gitignore
+++ b/parser/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/parser/.gitignore
+++ b/parser/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
When using certain plugins, builtin `vim.io.select` misbehaves to the point where it's unusable.
Since this plugin already uses telescope, I thought it could be useful here as well.

This is working (for me) proof of concept.

At the moment I couldn't test version for `picker = "snacks"`, but i wrote something that might work.