### PR TITLE
feat(snacks): register snacks pickers

### DIFF
--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -11,6 +11,13 @@ local function set_picker(opts)
     opts = {}
   end
   if package.loaded["snacks"] then
+    Snacks.picker["apidocs_open"] = function(picker_opts)
+      require('apidocs.snacks').apidocs_open({}, picker_opts)
+    end
+    Snacks.picker["apidocs_search"] = function(picker_opts)
+      require('apidocs.snacks').apidocs_search({}, picker_opts)
+    end
+
     opts.picker = "snacks"
     return opts
   end

--- a/lua/apidocs/snacks.lua
+++ b/lua/apidocs/snacks.lua
@@ -66,30 +66,26 @@ local function format_entries(item, picker)
   return new_item
 end
 
-local function apidocs_open(opts)
-  Snacks.picker.files({
+local function get_picker_opts(opts, picker_opts)
+  local defaults = {
     layout = common_layout_options,
     win = common_win_options,
     dirs = get_data_dirs(opts),
     ft = { "markdown", "md" },
-    confirm = function(picker, item)
+    confirm = function(_, item)
       require("apidocs").open_doc_in_new_window(item.file)
     end,
     format = format_entries,
-  })
+  }
+  return vim.tbl_deep_extend("force", defaults, picker_opts or {})
 end
 
-local function apidocs_search(opts)
-  Snacks.picker.grep({
-    layout = common_layout_options,
-    win = common_win_options,
-    dirs = get_data_dirs(opts),
-    ft = { "markdown", "md" },
-    confirm = function(picker, item)
-      require("apidocs").open_doc_in_new_window(item.file)
-    end,
-    format = format_entries,
-  })
+local function apidocs_open(opts, picker_opts)
+  Snacks.picker.files(get_picker_opts(opts, picker_opts))
+end
+
+local function apidocs_search(opts, picker_opts)
+  Snacks.picker.grep(get_picker_opts(opts, picker_opts))
 end
 
 return {


### PR DESCRIPTION
Hi, thanks for a nice plugin!

This PR registers `apidocs_open` and `apidocs_search` into Snacks so we can configure them the same way we do built-in pickers.

For example, `Snacks.picker.apidocs_open({ layout = "vscode" })`.