### PR TITLE
Two Bug Fixes

### DIFF
--- a/lua/apidocs.lua
+++ b/lua/apidocs.lua
@@ -99,7 +99,7 @@ local function ensure_install(languages)
 end
 
 -- ignore the ensure_installed option, that's handled by apidocs_open
-local function apidocs_open_only()
+local function apidocs_open_only(opts)
   local picker = Config.picker
   if opts and opts.picker then
     picker = opts.picker

--- a/lua/apidocs/common.lua
+++ b/lua/apidocs/common.lua
@@ -40,7 +40,7 @@ local function buf_view_switch_to_new(new_buf)
 end
 
 local function open_doc_in_cur_window(docs_path)
-  local buf = vim.api.nvim_create_buf(true, false)
+  local buf = vim.api.nvim_create_buf(false, true) -- unlisted, scratch
   local follow_link_keymap = Config and Config.follow_link_keymap or "<C-]>"
   vim.api.nvim_win_set_buf(0, buf)
   vim.wo.conceallevel = 2


### PR DESCRIPTION
Fixed a bug preventing filtering docs by file type from working. The solution was a simple one line change, passing in opts to the apidocs_open_only function `local function apidocs_open_only(opts)


Fixed a bug causing the selected file to be copied onto the users project directory. The solution was a simple one line change in common.lua   `local buf = vim.api.nvim_create_buf(false, true) -- unlisted, scratch` 

This plugin is great by the way. Extremely useful and amount of time I've spent context switching. Keep it up.